### PR TITLE
Extract mdfreader example

### DIFF
--- a/docs/mdfreader.md
+++ b/docs/mdfreader.md
@@ -12,53 +12,8 @@ The reader object handles all versions of MDF. The object is either created thro
 declaring the reader. Example of usage below:
 
 ~~~~c++
-#include <mdf/mdfreader.h>
-#using namespace mdf;
 
-MdfReader reader("c:/mdf/example.mf4");  // Note the file is now open.
-
-// Read all blocks but not the raw data and attachments.
-// This reads in the block information into memory.
-reader.ReadEverythingButData();          
-                                         
-const auto* mdf_file = reader.GetFile(); // Get the file interface.
-DataGroupList dg_list;                   // Get all measurements.
-mdf_file.DataGroups(dg_list);            
-
-// In this example, we read in all sample data and fetch all values.
-for (const auto* dg4 : dg_list) {
-  // Subscribers holds the sample data for a channel.
-  // You should normally only subscribe on some channels. 
-  // We need a list to hold them.
-  ChannelObserverList subscriber_list;       
-  const auto cg_list = dg4->ChannelGroups(); 
-  for (const auto* cg4 : cg_list ) {
-    const auto cn_list = cg4->Channels(); 
-    for (const auto* cn4 : cn_list) {
-      // Create a subscriber and add it to the temporary list
-      auto sub = reader.CreateChannelObserver(*dg4, *cg4, *cn4);
-      subscriber_list.push_back(std::move(sub));
-    }
-  }
-  
-  // Now it is time to read in all samples 
-  reader.ReadData(*dg4); // Read raw data from file
-  double channel_value = 0.0; Channel value (no scaling)
-  double eng_value = 0.0; // Engineering value
-  for (auto& obs : subscriber_list) {
-    for (size_t sample = 0; sample < obs->NofSamples(); ++sample) {
-      const auto channel_valid = obs->GetChannelValue(csample, hannel_value);
-      const auto eng_valid = sub->GetEngValue(sample, eng_value);
-      // You should do something with data here
-    }
-  }
-  
-  // Not needed in this example as we delete the subscribers,
-  // but it is good practise to remove samples data from memory
-  // when it is no longer needed.
-  dg4->ResetSample();   
-}
-reader.Close(); // Close the file
+{% include_relative mdfreaderexample.cpp %}
 ~~~~
 
 ## Reading from the File

--- a/docs/mdfreaderexample.cpp
+++ b/docs/mdfreaderexample.cpp
@@ -1,0 +1,47 @@
+#include <mdf/mdfreader.h>
+#using namespace mdf;
+
+MdfReader reader("c:/mdf/example.mf4");  // Note the file is now open.
+
+// Read all blocks but not the raw data and attachments.
+// This reads in the block information into memory.
+reader.ReadEverythingButData();          
+                                         
+const auto* mdf_file = reader.GetFile(); // Get the file interface.
+DataGroupList dg_list;                   // Get all measurements.
+mdf_file.DataGroups(dg_list);            
+
+// In this example, we read in all sample data and fetch all values.
+for (const auto* dg4 : dg_list) {
+  // Subscribers holds the sample data for a channel.
+  // You should normally only subscribe on some channels. 
+  // We need a list to hold them.
+  ChannelObserverList subscriber_list;       
+  const auto cg_list = dg4->ChannelGroups(); 
+  for (const auto* cg4 : cg_list ) {
+    const auto cn_list = cg4->Channels(); 
+    for (const auto* cn4 : cn_list) {
+      // Create a subscriber and add it to the temporary list
+      auto sub = reader.CreateChannelObserver(*dg4, *cg4, *cn4);
+      subscriber_list.push_back(std::move(sub));
+    }
+  }
+  
+  // Now it is time to read in all samples 
+  reader.ReadData(*dg4); // Read raw data from file
+  double channel_value = 0.0; Channel value (no scaling)
+  double eng_value = 0.0; // Engineering value
+  for (auto& obs : subscriber_list) {
+    for (size_t sample = 0; sample < obs->NofSamples(); ++sample) {
+      const auto channel_valid = obs->GetChannelValue(csample, hannel_value);
+      const auto eng_valid = sub->GetEngValue(sample, eng_value);
+      // You should do something with data here
+    }
+  }
+  
+  // Not needed in this example as we delete the subscribers,
+  // but it is good practise to remove samples data from memory
+  // when it is no longer needed.
+  dg4->ResetSample();   
+}
+reader.Close(); // Close the file


### PR DESCRIPTION
move mdfreaderexample into own file, so it can be used also in the unittests

The problem is to hold this example up to date. So the idea is to use this file in an unittest project so it can be evaluated that it is working.

@ihedvall can you test if the page gets build as before?