### PR TITLE
do not fetch expat if found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,9 @@ target_include_directories(mdf PRIVATE ${expat_SOURCE_DIR}/expat/lib)
 target_compile_definitions(mdf PRIVATE XML_STATIC)
 
 set(MDF_PUBLIC_HEADERS
+        include/mdf/etag.h
         include/mdf/iattachment.h
+        include/mdf/iblock.h
         include/mdf/ichannel.h
         include/mdf/ichannelconversion.h
         include/mdf/ichannelgroup.h
@@ -129,6 +131,7 @@ set(MDF_PUBLIC_HEADERS
         include/mdf/mdffile.h
         include/mdf/mdfreader.h
         include/mdf/mdfhelper.h # TODO: is there a possibility to get this away?
+        include/mdf/imetadata.h
 )
 
 set_target_properties(mdf PROPERTIES PUBLIC_HEADER "${MDF_PUBLIC_HEADERS}")

--- a/script/fetch_expat.cmake
+++ b/script/fetch_expat.cmake
@@ -3,6 +3,7 @@
 include(FetchContent)
 include(CMakePrintHelpers)
 
+include(FindEXPAT)
 if (NOT EXPAT_FOUND)
     FetchContent_Declare(expat
         GIT_REPOSITORY https://github.com/libexpat/libexpat.git

--- a/test/TestMDFCMake/CMakeLists.txt
+++ b/test/TestMDFCMake/CMakeLists.txt
@@ -7,5 +7,5 @@ project(mdfTestReadExample
 find_package(MdfLib REQUIRED)
 
 add_executable(TestMDFCMake ../../docs/mdfreaderexample.cpp)
-target_link_libraries(TestMDFCMake Upstream::mdf Upstream::expat)
+target_link_libraries(TestMDFCMake Upstream::mdf)
 target_include_directories(TestMDFCMake PRIVATE ${MdfLibTargets_INCLUDE_DIR})

--- a/test/TestMDFCMake/CMakeLists.txt
+++ b/test/TestMDFCMake/CMakeLists.txt
@@ -4,6 +4,8 @@ project(mdfTestReadExample
         DESCRIPTION "Test find_package mdf"
         LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(MdfLib REQUIRED)
 
 add_executable(TestMDFCMake ../../docs/mdfreaderexample.cpp)


### PR DESCRIPTION
The problem is, if the package is already installed on the system it is not possible to install mdflib, because expat files are already installed.

Probably only a problem for Linux with a package manager.

MDFlib in the Arch Linux repository
https://aur.archlinux.org/packages/mdflib-git