### PR TITLE
Modify CMake to include Boost dependencies for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,6 @@ add_library(mdf STATIC
 
 target_link_libraries(mdf ${ZLIB_LIBRARIES} expat)
 
-if (UNIX)
-  target_link_libraries(mdf rt icuuc icui18n)
-endif (UNIX)
-
 target_include_directories(mdf PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ add_library(mdf STATIC
 
 target_link_libraries(mdf ${ZLIB_LIBRARIES} expat)
 
+if (UNIX)
+  target_link_libraries(mdf rt icuuc icui18n)
+endif (UNIX)
+
 target_include_directories(mdf PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/mdfviewer/CMakeLists.txt
+++ b/mdfviewer/CMakeLists.txt
@@ -55,3 +55,7 @@ if (WIN32)
 target_link_libraries(mdfview PRIVATE bcrypt)
 target_link_libraries(mdfview PRIVATE ws2_32)
 endif()
+
+if (UNIX)
+target_link_libraries(mdfview PRIVATE rt icuuc icui18n)
+endif (UNIX)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,10 @@ if (WIN32)
     target_link_libraries(test_mdf PRIVATE mswsock)
 endif ()
 
+if (UNIX)
+    target_link_libraries(test_mdf PRIVATE rt)
+endif (UNIX)
+
 include(GoogleTest)
 gtest_discover_tests(test_mdf)
 


### PR DESCRIPTION
This pull request adds the necessary Boost-specific libraries 'rt', 'icuuc', and 'icui18n' to the CMake configuration for Linux support. These libraries are used for Boost functionality, enabling features such as real-time processing and Unicode support.

Please review the changes and let me know if any further adjustments are required. Thank you!

O.S. Ubuntu 20.04.4 LTS
g++-10 version 10.3.0
gcc-10 version 10.3.0
boost version 1.71.0