### PR TITLE
build: fix build for g++-10

### DIFF
--- a/mdflib/src/ichannelgroup.cpp
+++ b/mdflib/src/ichannelgroup.cpp
@@ -7,6 +7,8 @@
 
 #include "mdf/mdfhelper.h"
 
+#include <algorithm>
+
 namespace mdf {
 
 SampleRecord IChannelGroup::GetSampleRecord() const {

--- a/mdflib/src/mdfwriter.cpp
+++ b/mdflib/src/mdfwriter.cpp
@@ -629,7 +629,7 @@ void MdfWriter::CreateCanDataFrameChannel(IChannelGroup& group) const {
           cc_length->Parameter(index++,key);
           cc_length->Parameter(index++,CanMessage::DlcToLength(key));
         }
-        cc_length->Parameter(index, 0ULL);
+        cc_length->Parameter(index, static_cast<uint64_t>(0ULL));
       }
     }
   }
@@ -739,7 +739,7 @@ void MdfWriter::CreateCanRemoteFrameChannel(IChannelGroup& group) {
           cc_length->Parameter(index++,key);
           cc_length->Parameter(index++,CanMessage::DlcToLength(key));
         }
-        cc_length->Parameter(index, 0ULL);
+        cc_length->Parameter(index, static_cast<uint64_t>(0ULL));
       }
     }
   }
@@ -821,7 +821,7 @@ void MdfWriter::CreateCanErrorFrameChannel(IChannelGroup& group) const {
           cc_length->Parameter(index++,key);
           cc_length->Parameter(index++,CanMessage::DlcToLength(key));
         }
-        cc_length->Parameter(index, 0ULL);
+        cc_length->Parameter(index, static_cast<uint64_t>(0ULL));
       }
     }
   }


### PR DESCRIPTION
@ihedvall Hi, I got these errors when building with g++-10. Could you review it? :bow: 

```
mdflib/mdflib/src/ichannelgroup.cpp:44:19: error: 'find_if' is not a member of 'std'; did you mean 'find'?
   44 |   auto itr = std::find_if(cn_list.begin(), cn_list.end(),
      |                   ^~~~~~~
      |                   find
```

```
 
mdflib/mdflib/src/mdfwriter.cpp:824:41: error: call of overloaded 'Parameter(size_t&, long long unsigned int)' is ambiguous
  824 |         cc_length->Parameter(index, 0ULL);
      |                                         ^
In file included from mdflib/mdflib/../include/mdf/ichannel.h:17,
                 from mdflib/mdflib/../include/mdf/ichannelgroup.h:13,
                 from mdflib/mdflib/../include/mdf/idatagroup.h:14,
                 from mdflib/mdflib/src/mdfwriter.cpp:8:
mdflib/mdflib/../include/mdf/ichannelconversion.h:195:8: note: candidate: 'void mdf::IChannelConversion::Parameter(size_t, double)'
  195 |   void Parameter(size_t index, double parameter);
      |        ^~~~~~~~~
mdflib/mdflib/../include/mdf/ichannelconversion.h:215:8: note: candidate: 'void mdf::IChannelConversion::Parameter(size_t, uint64_t)'
  215 |   void Parameter(size_t index, uint64_t parameter);
```