### PR TITLE
Added the 'phtread' link flag to fix the issue that the compilation routine could not be linked

### DIFF
--- a/mdflibrary_example/CMakeLists.txt
+++ b/mdflibrary_example/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
                                                   "-Wl,-rpath,'$ORIGIN'")
 endif()
 
-target_link_libraries(mdflibraryexample PRIVATE mdflibrary)
+target_link_libraries(mdflibraryexample PRIVATE mdflibrary pthread)
 
 target_include_directories(
   mdflibrary PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)


### PR DESCRIPTION
![image](https://github.com/ihedvall/mdflib/assets/22984011/a2c586c9-68ed-4901-97db-0ecc93722ab1)
