### PR TITLE
Add missing `cstdint` include

### DIFF
--- a/mdfviewer/src/util/logging.h
+++ b/mdfviewer/src/util/logging.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 


### PR DESCRIPTION
Some platforms need this header to be included explicitly