### PR TITLE
Save channel group headers right after saving data

### DIFF
--- a/mdflib/src/mdfwriter.cpp
+++ b/mdflib/src/mdfwriter.cpp
@@ -461,7 +461,14 @@ void MdfWriter::SaveQueue(std::unique_lock<std::mutex>& lock) {
     lock.lock();
   }
 
+  // Update channel group headers to reflect the new number of samples
   lock.unlock();
+  for (const auto& cg3 : dg3->Cg3()) {
+    if (cg3 != nullptr) {
+      cg3->Write(file);
+    }
+  }
+
   fclose(file);
   lock.lock();
 }


### PR DESCRIPTION
If the program generating the MDF file was interrupted to never recover again, the current measurement would be completely lost, even though data was being periodically written to the file.

The problem was that the channel group header was not being written to the file to reflect the updated number of samples.

This function appears to be called sporadically enough that these writes shouldn't be a problem.