### PR TITLE
fix: missing Tx and order issues in HDcomment

### DIFF
--- a/mdflib/src/mdfblock.cpp
+++ b/mdflib/src/mdfblock.cpp
@@ -845,6 +845,10 @@ void MdfBlock::CreateMd4Block() {
     const auto *tx4 = dynamic_cast<const Tx4Block *>(md_comment_.get());
     xml->SetProperty("TX", tx4 != nullptr ? tx4->TxComment() : std::string());
   }
+  
+  if (this->BlockType() == "HD") {
+    xml->SetProperty("TX", std::string());
+  }
 
   md4->XmlSnippet(xml->WriteString(true));
   md_comment_ = std::move(md4);


### PR DESCRIPTION
Since the HD block is unique and must contain Tx, I modified it to pre-add the Tx element when creating the HD block. This avoids issues related to missing Tx or incorrect order when it is not set or the order is uncertain.

fixed #118 