### PR TITLE
Add missing public headers

### DIFF
--- a/mdflib/CMakeLists.txt
+++ b/mdflib/CMakeLists.txt
@@ -154,6 +154,7 @@ endif()
 
 set(MDF_PUBLIC_HEADERS
     ../include/mdf/cryptoutil.h
+    ../include/mdf/canmessage.h
     ../include/mdf/etag.h
     ../include/mdf/iattachment.h
     ../include/mdf/iblock.h
@@ -170,6 +171,8 @@ set(MDF_PUBLIC_HEADERS
     ../include/mdf/imetadata.h
     ../include/mdf/isampleobserver.h
     ../include/mdf/isourceinformation.h
+    ../include/mdf/itimestamp.h
+    ../include/mdf/imdftimestamp.h
     ../include/mdf/mdffactory.h
     ../include/mdf/mdffile.h
     ../include/mdf/mdfhelper.h


### PR DESCRIPTION
These I found are required when using the static lib but missing from copied headers.

itimestamp.h and imdftimestamp.h both in .iheader.h already public:
https://github.com/ihedvall/mdflib/blob/main/include/mdf/iheader.h

canmessage.h:
https://github.com/ihedvall/mdflib/blob/main/include/mdf/mdfwriter.h#L16

I guess by that logic linmessage.h and ethmessage.h should also be public?