### PR TITLE
Add missing public headers 

### DIFF
--- a/mdflib/CMakeLists.txt
+++ b/mdflib/CMakeLists.txt
@@ -194,7 +194,7 @@ set(MDF_PUBLIC_HEADERS
     ../include/mdf/hoadmindata.h
     ../include/mdf/hocompumethod.h
     ../include/mdf/hocompuscale.h
-    ../include/mdf/hoenumerate.h
+    ../include/mdf/hoenumerates.h
     ../include/mdf/hointerval.h
     ../include/mdf/honamedetails.h
     ../include/mdf/hophysicaldimension.h
@@ -239,6 +239,7 @@ set(MDF_PUBLIC_HEADERS
     ../include/mdf/mdstring.h
     ../include/mdf/mdsyntax.h
     ../include/mdf/mdvariable.h
+    ../include/mdf/isamplereduction.h
     ../include/mdf/samplerecord.h
     ../include/mdf/sicomment.h
     ../include/mdf/zlibutil.h)


### PR DESCRIPTION
Hi,

I think some headers were not installed correctly:
- `hoenumerate.h` have probably been renamed to `hoenumerates.h` recently.
- When I linked my project to the library `isamplereduction.h` was missing 