### PR TITLE
Set install interface to find includes when linking target

### DIFF
--- a/mdflib/CMakeLists.txt
+++ b/mdflib/CMakeLists.txt
@@ -167,7 +167,10 @@ else()
 endif()
 
 target_include_directories(
-  mdf PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
+  mdf PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set_target_properties(mdf PROPERTIES COMPILE_FLAGS "-fPIC")


### PR DESCRIPTION
Hi, when I tried to link the mdf library with cmake, e.g:

```
target_link_libraries(${CMAKE_PROJECT_NAME}
  PRIVATE
    Upstream::mdf
)
```
I get a `No such file or directory` error.  I think include directories are typically set on the target with modern cmake.

This fix set an `INSTALL_INTERFACE` on the library target.