### PR TITLE
Add LinMessage export wrapper to mdflibrary

### DIFF
--- a/include/mdflibrary/LinMessage.h
+++ b/include/mdflibrary/LinMessage.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Julles
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+#include <stdexcept>
+#include <vector>
+
+#include "MdfExport.h"
+
+using namespace MdfLibrary::ExportFunctions;
+
+namespace MdfLibrary {
+class LinMessage {
+ private:
+  bool isNew = false;
+  mdf::LinMessage* lin;
+
+ public:
+  LinMessage(mdf::LinMessage* lin) : lin(lin) {
+    if (lin == nullptr) throw std::runtime_error("LinMessage Init failed");
+  }
+  LinMessage() : LinMessage(LinMessageInit()) { isNew = true; };
+  ~LinMessage() {
+    if (isNew) LinMessageUnInit(lin);
+    lin = nullptr;
+  };
+  LinMessage(const LinMessage&) = delete;
+  LinMessage(LinMessage&& other) {
+    if (isNew) LinMessageUnInit(this->lin);
+    this->isNew = other.isNew;
+    this->lin = other.lin;
+    other.isNew = false;
+    other.lin = nullptr;
+  }
+
+  mdf::LinMessage* GetLinMessage() const { return lin; }
+
+  void SetLinId(uint8_t id) { LinMessageSetLinId(lin, id); };
+  uint8_t GetLinId() const { return LinMessageGetLinId(lin); };
+
+  void SetBusChannel(uint8_t channel) {
+    LinMessageSetBusChannel(lin, channel);
+  };
+  uint8_t GetBusChannel() const { return LinMessageGetBusChannel(lin); };
+
+  void SetDir(bool transmit) { LinMessageSetDir(lin, transmit); };
+  bool GetDir() const { return LinMessageGetDir(lin); };
+
+  void SetDataLength(uint8_t len) { LinMessageSetDataLength(lin, len); };
+  uint8_t GetDataLength() const { return LinMessageGetDataLength(lin); };
+
+  void SetReceivedDataByteCount(uint8_t len) {
+    LinMessageSetReceivedDataByteCount(lin, len);
+  };
+  uint8_t GetReceivedDataByteCount() const {
+    return LinMessageGetReceivedDataByteCount(lin);
+  };
+
+  std::vector<uint8_t> GetDataBytes() const {
+    size_t count = LinMessageGetDataBytes(lin, nullptr);
+    if (count <= 0) return {};
+    auto data = std::vector<uint8_t>(count);
+    LinMessageGetDataBytes(lin, data.data());
+    return data;
+  };
+  void SetDataBytes(const std::vector<uint8_t>& data) {
+    LinMessageSetDataBytes(lin, data.data(), data.size());
+  };
+  void SetDataBytes(const uint8_t* data, const size_t size) {
+    LinMessageSetDataBytes(lin, data, size);
+  };
+
+  void SetChecksum(uint8_t crc) { LinMessageSetChecksum(lin, crc); };
+  uint8_t GetChecksum() const { return LinMessageGetChecksum(lin); };
+
+  void SetChecksumModel(int model) { LinMessageSetChecksumModel(lin, model); };
+  int GetChecksumModel() const { return LinMessageGetChecksumModel(lin); };
+
+  void SetStartOfFrame(uint64_t ns1970) {
+    LinMessageSetStartOfFrame(lin, ns1970);
+  };
+  uint64_t GetStartOfFrame() const { return LinMessageGetStartOfFrame(lin); };
+
+  void SetBaudrate(float baud) { LinMessageSetBaudrate(lin, baud); };
+  float GetBaudrate() const { return LinMessageGetBaudrate(lin); };
+
+  void SetResponseBaudrate(float baud) {
+    LinMessageSetResponseBaudrate(lin, baud);
+  };
+  float GetResponseBaudrate() const {
+    return LinMessageGetResponseBaudrate(lin);
+  };
+
+  void SetBreakLength(uint32_t len) { LinMessageSetBreakLength(lin, len); };
+  uint32_t GetBreakLength() const { return LinMessageGetBreakLength(lin); };
+};
+}  // namespace MdfLibrary

--- a/include/mdflibrary/MdfExport.h
+++ b/include/mdflibrary/MdfExport.h
@@ -23,6 +23,7 @@ class IEvent;
 class ETag;
 class IMetaData;
 class CanMessage;
+class LinMessage;
 }  // namespace mdf
 
 namespace MdfLibrary {
@@ -383,6 +384,30 @@ enum class MessageType : int {
   CAN_ErrorFrame,     ///< Error message.
   CAN_OverloadFrame,  ///< Overload frame message.
 };
+
+enum class LinMessageType : int {
+  LIN_Frame = 0,             ///< Standard LIN data frame.
+  LIN_WakeUp = 1,            ///< Wake-up frame detected on the bus.
+  LIN_ChecksumError = 2,     ///< Frame with checksum error.
+  LIN_TransmissionError = 3, ///< Transmission error occurred.
+  LIN_SyncError = 4,         ///< Synchronization error.
+  LIN_ReceiveError = 5,      ///< Receive error (unexpected length etc.).
+  LIN_Spike = 6,             ///< Short spike or glitch detected.
+  LIN_LongDominantSignal = 7 ///< Long dominant signal (bus stuck low/high).
+};
+
+enum class LinChecksumModel : int {
+  Unknown = -1, ///< Checksum model unknown or not specified.
+  Classic = 0,  ///< Classic (8-bit) LIN checksum model.
+  Enhanced = 1  ///< Enhanced (including protected ID) LIN checksum.
+};
+
+enum class LinTypeOfLongDominantSignal : int {
+  FirstDetection = 0, ///< Initial detection of a long dominant signal.
+  CyclicReport = 1,   ///< Periodic/cyclic reporting of long dominant.
+  EndOfDetection = 2  ///< End or release of the long dominant signal.
+};
+
 }  // namespace MdfLibrary
 
 #if defined(_WIN32)
@@ -454,6 +479,8 @@ EXPORTFEATUREFUNC(bool, InitMeasurement);
 EXPORTFEATUREFUNC(void, SaveSample, mdf::IChannelGroup* group, uint64_t time);
 EXPORTFEATUREFUNC(void, SaveCanMessage, mdf::IChannelGroup* group,
                   uint64_t time, mdf::CanMessage* message);
+EXPORTFEATUREFUNC(void, SaveLinMessage, mdf::IChannelGroup* group,
+                  uint64_t time, mdf::LinMessage* message);
 EXPORTFEATUREFUNC(void, StartMeasurement, uint64_t start_time);
 EXPORTFEATUREFUNC(void, StopMeasurement, uint64_t stop_time);
 EXPORTFEATUREFUNC(bool, FinalizeMeasurement);
@@ -917,6 +944,38 @@ EXPORTFEATUREFUNC(uint8_t, GetBitPosition);
 EXPORTFEATUREFUNC(void, SetBitPosition, const uint8_t position);
 EXPORTFEATUREFUNC(CanErrorType, GetErrorType);
 EXPORTFEATUREFUNC(void, SetErrorType, const CanErrorType type);
+#undef EXPORTFEATUREFUNC
+#pragma endregion
+
+#pragma region mdf::LinMessage
+EXPORT(mdf::LinMessage*, LinMessage, Init);
+#define EXPORTFEATUREFUNC(ReturnType, FuncName, ...) \
+  EXPORT(ReturnType, LinMessage, FuncName, mdf::LinMessage* lin, ##__VA_ARGS__)
+EXPORTFEATUREFUNC(void, UnInit);
+EXPORTFEATUREFUNC(void, SetLinId, uint8_t id);
+EXPORTFEATUREFUNC(uint8_t, GetLinId);
+EXPORTFEATUREFUNC(void, SetBusChannel, uint8_t channel);
+EXPORTFEATUREFUNC(uint8_t, GetBusChannel);
+EXPORTFEATUREFUNC(void, SetDir, bool transmit);
+EXPORTFEATUREFUNC(bool, GetDir);
+EXPORTFEATUREFUNC(void, SetDataLength, uint8_t len);
+EXPORTFEATUREFUNC(uint8_t, GetDataLength);
+EXPORTFEATUREFUNC(void, SetReceivedDataByteCount, uint8_t len);
+EXPORTFEATUREFUNC(uint8_t, GetReceivedDataByteCount);
+EXPORTFEATUREFUNC(size_t, GetDataBytes, uint8_t* buffer);
+EXPORTFEATUREFUNC(void, SetDataBytes, const uint8_t* data, size_t size);
+EXPORTFEATUREFUNC(void, SetChecksum, uint8_t crc);
+EXPORTFEATUREFUNC(uint8_t, GetChecksum);
+EXPORTFEATUREFUNC(void, SetChecksumModel, int model);
+EXPORTFEATUREFUNC(int, GetChecksumModel);
+EXPORTFEATUREFUNC(void, SetStartOfFrame, uint64_t ns1970);
+EXPORTFEATUREFUNC(uint64_t, GetStartOfFrame);
+EXPORTFEATUREFUNC(void, SetBaudrate, float baud);
+EXPORTFEATUREFUNC(float, GetBaudrate);
+EXPORTFEATUREFUNC(void, SetResponseBaudrate, float baud);
+EXPORTFEATUREFUNC(float, GetResponseBaudrate);
+EXPORTFEATUREFUNC(void, SetBreakLength, uint32_t len);
+EXPORTFEATUREFUNC(uint32_t, GetBreakLength);
 #undef EXPORTFEATUREFUNC
 #pragma endregion
 }}  // namespace MdfLibrary::ExportFunctions

--- a/include/mdflibrary/MdfWriter.h
+++ b/include/mdflibrary/MdfWriter.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "MdfFile.h"
 #include "CanMessage.h"
+#include "LinMessage.h"
 
 using namespace MdfLibrary::ExportFunctions;
 
@@ -56,6 +57,9 @@ class MdfWriter {
   }
   void SaveCanMessage(const MdfChannelGroup group, uint64_t time, const CanMessage& msg) {
     MdfWriterSaveCanMessage(writer, group.GetChannelGroup(), time, msg.GetCanMessage());
+  }
+  void SaveLinMessage(const MdfChannelGroup group, uint64_t time, const LinMessage& msg) {
+    MdfWriterSaveLinMessage(writer, group.GetChannelGroup(), time, msg.GetLinMessage());
   }
   bool InitMeasurement() { return MdfWriterInitMeasurement(writer); }
   void StartMeasurement(uint64_t start_time) {

--- a/mdflibrary/CMakeLists.txt
+++ b/mdflibrary/CMakeLists.txt
@@ -76,7 +76,8 @@ set(MDFLIBRARY_PUBLIC_HEADERS
             ../include/mdflibrary/MdfReader.h
             ../include/mdflibrary/MdfSourceInformation.h
             ../include/mdflibrary/MdfWriter.h
-            ../include/mdflibrary/CanMessage.h)
+            ../include/mdflibrary/CanMessage.h
+            ../include/mdflibrary/LinMessage.h)
 set_target_properties(mdflibrary PROPERTIES PUBLIC_HEADER
                                             "${MDFLIBRARY_PUBLIC_HEADERS}")
 get_target_property(PH1 mdflibrary PUBLIC_HEADER)

--- a/mdflibrary/src/MdfExport.cpp
+++ b/mdflibrary/src/MdfExport.cpp
@@ -10,6 +10,7 @@
 #include <mdf/idatagroup.h>
 #include <mdf/ievent.h>
 #include <mdf/ifilehistory.h>
+#include <mdf/linmessage.h>
 #include <mdf/mdffactory.h>
 #include <mdf/mdfreader.h>
 #include <mdf/mdfwriter.h>
@@ -119,6 +120,10 @@ EXPORTFEATUREFUNC(void, SaveSample, mdf::IChannelGroup* group, uint64_t time) {
 EXPORTFEATUREFUNC(void, SaveCanMessage, mdf::IChannelGroup* group,
                   uint64_t time, mdf::CanMessage* message) {
   writer->SaveCanMessage(*group, time, *message);
+}
+EXPORTFEATUREFUNC(void, SaveLinMessage, mdf::IChannelGroup* group,
+                 uint64_t time, const mdf::LinMessage* message) {
+  writer->SaveLinMessage(*group, time, *message);
 }
 EXPORTFEATUREFUNC(void, StartMeasurement, uint64_t start_time) {
   writer->StartMeasurement(start_time);
@@ -1188,6 +1193,62 @@ EXPORTFEATUREFUNC(CanErrorType, GetErrorType) { return can->ErrorType(); }
 EXPORTFEATUREFUNC(void, SetErrorType, const CanErrorType type) {
   can->ErrorType(type);
 }
+#undef EXPORTFEATUREFUNC
+#pragma endregion
+
+#pragma region LinMessage
+EXPORT(mdf::LinMessage*, LinMessage, Init) { return new mdf::LinMessage; }
+#define EXPORTFEATUREFUNC(ReturnType, FuncName, ...) \
+  EXPORT(ReturnType, LinMessage, FuncName, mdf::LinMessage* lin, ##__VA_ARGS__)
+EXPORTFEATUREFUNC(void, UnInit) { delete lin; }
+EXPORTFEATUREFUNC(void, SetLinId, uint8_t id) { lin->LinId(id); }
+EXPORTFEATUREFUNC(uint8_t, GetLinId) { return lin->LinId(); }
+EXPORTFEATUREFUNC(void, SetBusChannel, uint8_t channel) {
+  lin->BusChannel(channel);
+}
+EXPORTFEATUREFUNC(uint8_t, GetBusChannel) { return lin->BusChannel(); }
+EXPORTFEATUREFUNC(void, SetDir, bool transmit) { lin->Dir(transmit); }
+EXPORTFEATUREFUNC(bool, GetDir) { return lin->Dir(); }
+EXPORTFEATUREFUNC(void, SetDataLength, uint8_t len) { lin->DataLength(len); }
+EXPORTFEATUREFUNC(uint8_t, GetDataLength) { return lin->DataLength(); }
+EXPORTFEATUREFUNC(void, SetReceivedDataByteCount, uint8_t len) {
+  lin->ReceivedDataByteCount(len);
+}
+EXPORTFEATUREFUNC(uint8_t, GetReceivedDataByteCount) {
+  return lin->ReceivedDataByteCount();
+}
+EXPORTFEATUREFUNC(size_t, GetDataBytes, uint8_t* buffer) {
+  const auto& v = lin->DataBytes();
+  if (buffer != nullptr) memcpy(buffer, v.data(), v.size());
+  return v.size();
+}
+EXPORTFEATUREFUNC(void, SetDataBytes, const uint8_t* data, size_t size) {
+  if (data == nullptr || size == 0) {
+    lin->DataBytes(std::vector<uint8_t>{});
+  } else {
+    lin->DataBytes(std::vector<uint8_t>(data, data + size));
+  }
+}
+EXPORTFEATUREFUNC(void, SetChecksum, uint8_t crc) { lin->Checksum(crc); }
+EXPORTFEATUREFUNC(uint8_t, GetChecksum) { return lin->Checksum(); }
+EXPORTFEATUREFUNC(void, SetChecksumModel, int model) {
+  lin->ChecksumModel(static_cast<mdf::LinChecksumModel>(model));
+}
+EXPORTFEATUREFUNC(int, GetChecksumModel) {
+  return static_cast<int>(lin->ChecksumModel());
+}
+EXPORTFEATUREFUNC(void, SetStartOfFrame, uint64_t ns1970) {
+  lin->StartOfFrame(ns1970);
+}
+EXPORTFEATUREFUNC(uint64_t, GetStartOfFrame) { return lin->StartOfFrame(); }
+EXPORTFEATUREFUNC(void, SetBaudrate, float baud) { lin->Baudrate(baud); }
+EXPORTFEATUREFUNC(float, GetBaudrate) { return lin->Baudrate(); }
+EXPORTFEATUREFUNC(void, SetResponseBaudrate, float baud) {
+  lin->ResponseBaudrate(baud);
+}
+EXPORTFEATUREFUNC(float, GetResponseBaudrate) { return lin->ResponseBaudrate(); }
+EXPORTFEATUREFUNC(void, SetBreakLength, uint32_t len) { lin->BreakLength(len); }
+EXPORTFEATUREFUNC(uint32_t, GetBreakLength) { return lin->BreakLength(); }
 #undef EXPORTFEATUREFUNC
 #pragma endregion
 }  // namespace MdfLibrary::ExportFunctions

--- a/mdflibrary_example/src/test.cpp
+++ b/mdflibrary_example/src/test.cpp
@@ -4,6 +4,7 @@
  */
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 // Pure C example
 #pragma region C
@@ -351,6 +352,69 @@ void cpp_example() {
       Writer.SaveCanMessage(can_remote_frame, tick_time, msg);
       Writer.SaveCanMessage(can_error_frame, tick_time, msg);
       Writer.SaveCanMessage(can_overload_frame, tick_time, msg);
+      tick_time += 1'000'000;
+    }
+    std::cout << "Stop measure" << std::endl;
+    Writer.StopMeasurement(1100000000);
+    Writer.FinalizeMeasurement();
+  }
+
+  {
+
+    std::cout << "Write Lin" << std::endl;
+    MdfWriter Writer(MdfWriterType::MdfBusLogger, "test_lin_cpp.mf4");
+    MdfHeader Header = Writer.GetHeader();
+    MdfFileHistory History = Header.CreateFileHistory();
+    History.SetDescription("Test LIN data types");
+    History.SetToolName("MdfWrite");
+    History.SetToolVendor("ACME Road Runner Company");
+    History.SetToolVersion("1.0");
+    History.SetUserName("Ingemar Hedvall");
+
+    Writer.SetBusType(MdfBusType::LIN);
+    Writer.SetStorageType(MdfStorageType::MlsdStorage);
+    Writer.SetMaxLength(8);
+    Writer.CreateBusLogConfiguration();
+    Writer.SetPreTrigTime(0.0);
+    Writer.SetCompressData(false);
+    MdfDataGroup last_dg = Header.GetLastDataGroup();
+
+    MdfChannelGroup lin_frame = last_dg.GetChannelGroup("LIN_Frame");
+    MdfChannelGroup lin_wake_up = last_dg.GetChannelGroup("LIN_WakeUp");
+    MdfChannelGroup lin_checksum_error =
+        last_dg.GetChannelGroup("LIN_ChecksumError");
+    MdfChannelGroup lin_transmission_error =
+        last_dg.GetChannelGroup("LIN_TransmissionError");
+    MdfChannelGroup lin_sync_error = last_dg.GetChannelGroup("LIN_SyncError");
+    MdfChannelGroup lin_receive_error =
+        last_dg.GetChannelGroup("LIN_ReceiveError");
+    MdfChannelGroup lin_spike = last_dg.GetChannelGroup("LIN_Spike");
+    MdfChannelGroup lin_long_dom = last_dg.GetChannelGroup("LIN_LongDom");
+
+    Writer.InitMeasurement();
+    uint64_t tick_time = 100000000;
+    Writer.StartMeasurement(tick_time);
+    std::cout << "Start measure" << std::endl;
+    for (size_t i = 0; i < 100'000; i++) {
+      std::vector<uint8_t> data;
+      data.assign(i < 8 ? i + 1 : 8, static_cast<uint8_t>(i + 1));
+
+      LinMessage msg;
+      msg.SetLinId(12);
+      msg.SetBusChannel(11);
+      msg.SetDir(true);
+      msg.SetDataLength(static_cast<uint8_t>(data.size()));
+      msg.SetReceivedDataByteCount(static_cast<uint8_t>(data.size()));
+      msg.SetDataBytes(data);
+
+      Writer.SaveLinMessage(lin_frame, tick_time, msg);
+      Writer.SaveLinMessage(lin_wake_up, tick_time, msg);
+      Writer.SaveLinMessage(lin_checksum_error, tick_time, msg);
+      Writer.SaveLinMessage(lin_transmission_error, tick_time, msg);
+      Writer.SaveLinMessage(lin_sync_error, tick_time, msg);
+      Writer.SaveLinMessage(lin_receive_error, tick_time, msg);
+      Writer.SaveLinMessage(lin_spike, tick_time, msg);
+      Writer.SaveLinMessage(lin_long_dom, tick_time, msg);
       tick_time += 1'000'000;
     }
     std::cout << "Stop measure" << std::endl;


### PR DESCRIPTION
Adds C export functions and a C++ wrapper class for `mdf::LinMessage` to the mdflibrary layer, mirroring the existing `CanMessage` bindings so external C/C++ consumers can construct, populate, and save LIN bus messages via `MdfWriter`.